### PR TITLE
flake.lock: nixos-24.05 → nixos-25.11, flake: vaguely test hm programs.vscode compat

### DIFF
--- a/alicorn-vscode-extension.nix
+++ b/alicorn-vscode-extension.nix
@@ -15,6 +15,20 @@ let
 
   src = ./.;
 
+  # Cursed: detect whether nixpkgs expects .vsix or .zip
+  # https://github.com/nix-community/nix-vscode-extensions/pull/164
+  dummyExt = vscode-utils.buildVscodeExtension {
+    pname = "";
+    version = "";
+    src = "";
+    vscodeExtUniqueId = "";
+    vscodeExtPublisher = "";
+    vscodeExtName = "";
+  };
+  dummyDeps = builtins.map (x: x.name) dummyExt.nativeBuildInputs;
+  isVsix = builtins.elem "unpack-vsix-setup-hook" dummyDeps;
+  fileExtension = if isVsix then "vsix" else "zip";
+
   vsix = buildNpmPackage {
     pname = "${pname}-vsix";
     inherit version src;
@@ -37,7 +51,7 @@ let
     postBuild = ''
       npm run compile
       mkdir -p $vsix
-      echo y | vsce package -o $vsix/${pname}.vsix
+      echo y | vsce package -o $vsix/${pname}.${fileExtension}
     '';
 
     preCheck = ''
@@ -49,7 +63,7 @@ in
 vscode-utils.buildVscodeExtension {
   inherit pname version vsix;
   name = "${pname}-${version}";
-  src = "${vsix}/${pname}.vsix";
+  src = "${vsix}/${pname}.${fileExtension}";
   vscodeExtUniqueId = "${publisher}.${pname}";
   vscodeExtPublisher = publisher;
   vscodeExtName = pname;

--- a/alicorn-vscode-extension.nix
+++ b/alicorn-vscode-extension.nix
@@ -37,7 +37,7 @@ let
     postBuild = ''
       npm run compile
       mkdir -p $vsix
-      echo y | vsce package -o $vsix/${pname}.zip
+      echo y | vsce package -o $vsix/${pname}.vsix
     '';
 
     preCheck = ''
@@ -49,7 +49,7 @@ in
 vscode-utils.buildVscodeExtension {
   inherit pname version vsix;
   name = "${pname}-${version}";
-  src = "${vsix}/${pname}.zip";
+  src = "${vsix}/${pname}.vsix";
   vscodeExtUniqueId = "${publisher}.${pname}";
   vscodeExtPublisher = publisher;
   vscodeExtName = pname;

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -57,32 +57,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723282977,
-        "narHash": "sha256-oTK91aOlA/4IsjNAZGMEBz7Sq1zBS0Ltu4/nIQdYDOg=",
+        "lastModified": 1766201043,
+        "narHash": "sha256-eplAP+rorKKd0gNjV3rA6+0WMzb1X1i16F5m5pASnjA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a781ff33ae258bbcfd4ed6e673860c3e923bf2cc",
+        "rev": "b3aad468604d3e488d627c0b43984eb60e75e782",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -93,15 +77,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1765911976,
+        "narHash": "sha256-t3T/xm8zstHRLx+pIHxVpQTiySbKqcQbK+r+01XVKc0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "b68b780b69702a090c8bb1b973bab13756cc7a27",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     "vscode extension for the Alicorn language";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";


### PR DESCRIPTION
extension was kill
```
unpacking source archive /nix/store/z89mgfxl18b9yd9lzprzi5lgsmi9h989-alicorn-vscode-extension-vsix-unstable-2023-12-25-vsix/alicorn-vscode-extension.zip
do not know how to unpack source archive /nix/store/z89mgfxl18b9yd9lzprzi5lgsmi9h989-alicorn-vscode-extension-vsix-unstable-2023-12-25-vsix/alicorn-vscode-extension.zip
```